### PR TITLE
FOGL-2838 Missing DEBIAN dir added under packages

### DIFF
--- a/packages/Debian/armhf/DEBIAN/control
+++ b/packages/Debian/armhf/DEBIAN/control
@@ -1,0 +1,10 @@
+Package: foglamp-filter-fft
+Version: 1.0.0
+Section: devel
+Priority: optional
+Architecture: armhf
+Depends: foglamp
+Conflicts:
+Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
+Homepage: http://www.dianomic.com
+Description: FogLAMP C++ fft filter plugin

--- a/packages/Debian/common/DEBIAN/postint
+++ b/packages/Debian/common/DEBIAN/postint
@@ -1,0 +1,34 @@
+#!/bin/sh
+
+##--------------------------------------------------------------------
+## Copyright (c) 2019 Dianomic Systems Inc
+##
+## Licensed under the Apache License, Version 2.0 (the "License");
+## you may not use this file except in compliance with the License.
+## You may obtain a copy of the License at
+##
+##     http://www.apache.org/licenses/LICENSE-2.0
+##
+## Unless required by applicable law or agreed to in writing, software
+## distributed under the License is distributed on an "AS IS" BASIS,
+## WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+## See the License for the specific language governing permissions and
+## limitations under the License.
+##--------------------------------------------------------------------
+
+##--------------------------------------------------------------------
+##
+## @postinst DEBIAN/postinst
+## This script is used to execute post installation tasks.
+##
+## Author: Ashish Jabble
+##
+##--------------------------------------------------------------------
+
+set -e
+
+set_files_ownership () {
+    chown -R root:root /usr/local/foglamp/plugins/filter/fft
+}
+
+set_files_ownership

--- a/packages/Debian/x86_64/DEBIAN/control
+++ b/packages/Debian/x86_64/DEBIAN/control
@@ -1,0 +1,10 @@
+Package: foglamp-filter-fft
+Version: 1.0.0
+Section: devel
+Priority: optional
+Architecture: amd64
+Depends: foglamp
+Conflicts:
+Maintainer: Dianomic Systems, Inc. <info@dianomic.com>
+Homepage: http://www.dianomic.com
+Description: FogLAMP C++ fft filter plugin


### PR DESCRIPTION
**./make_deb**

```
Scanning dependencies of target fft
[ 40%] Building CXX object CMakeFiles/fft.dir/plugin.o
[ 60%] Building CXX object CMakeFiles/fft.dir/fft_filter.o
[ 80%] Building C object CMakeFiles/fft.dir/fft.o
[100%] Linking CXX shared library libfft.so
[100%] Built target fft
Saving the old working environment as foglamp-filter-fft-1.5.2-x86_64.0001
Populating the package and updating version file...Done.
Building the new package...
dpkg-deb: building package 'foglamp-filter-fft' in 'foglamp-filter-fft-1.5.2-x86_64.deb'.
Building Complete.
```

**deb contents**
```
$ sudo dpkg -c /home/foglamp/Development/foglamp-filter-fft/packages/build/foglamp-filter-fft-1.5.2-x86_64.deb 
drwxrwxr-x foglamp/foglamp   0 2019-05-20 12:36 ./
drwxrwxr-x foglamp/foglamp   0 2019-05-20 12:36 ./usr/
drwxrwxr-x foglamp/foglamp   0 2019-05-20 12:36 ./usr/local/
drwxrwxr-x foglamp/foglamp   0 2019-05-20 12:36 ./usr/local/foglamp/
drwxrwxr-x foglamp/foglamp   0 2019-05-20 12:36 ./usr/local/foglamp/plugins/
drwxrwxr-x foglamp/foglamp   0 2019-05-20 12:36 ./usr/local/foglamp/plugins/filter/
drwxrwxr-x foglamp/foglamp   0 2019-05-20 12:36 ./usr/local/foglamp/plugins/filter/fft/
-rwxrwxr-x foglamp/foglamp 62376 2019-05-20 12:36 ./usr/local/foglamp/plugins/filter/fft/libfft.so.1

```